### PR TITLE
use new API for WSGI loader, for Django > 1.3

### DIFF
--- a/cc_django_wsgi.py
+++ b/cc_django_wsgi.py
@@ -6,6 +6,5 @@ sys.path.append("/home/bas/app_e7a18983-405e-4ada-ac68-2738f2767461")
 os.environ['DJANGO_SETTINGS_MODULE'] = 'cc_django.settings'
 os.environ['PYTHON_EGG_CACHE'] = '/tmp/.python-egg'
  
-import django.core.handlers.wsgi
- 
-application = django.core.handlers.wsgi.WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()


### PR DESCRIPTION
Hi,
This change is mandatory since django 1.7, you should include it to your example. The old API was deprecated since 1.4.
https://docs.djangoproject.com/en/1.7/releases/1.7/#wsgi-scripts
